### PR TITLE
Color Picker Broken #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Webpack copy of [Grafana default panel](http://docs.grafana.org/features/panels/
 
 The plugin is under development. Please goto [Build section](https://github.com/CorpGlory/grafana-multibar-graph-panel#build) to build it from source.
 
-Grafana 5.3.3+ support is priority.
+Supported Grafana versions: 5.3.3+
 
 # Screenshots
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Webpack copy of [Grafana default panel](http://docs.grafana.org/features/panels/
 
 The plugin is under development. Please goto [Build section](https://github.com/CorpGlory/grafana-multibar-graph-panel#build) to build it from source.
 
-Grafana 5.0 support is priority.
+Grafana 5.3.3+ support is priority.
 
 # Screenshots
 

--- a/src/graph_legend.ts
+++ b/src/graph_legend.ts
@@ -40,7 +40,7 @@ export class GraphLegend {
       position: 'bottom left',
       targetAttachment: 'top left',
       template:
-        '<series-color-picker series="series" onToggleAxis="toggleAxis" onColorChange="colorSelected"/>',
+        '<series-color-picker-popover series="series" onToggleAxis="toggleAxis" onColorChange="colorSelected"/>',
       openOn: 'hover',
       model: {
         series: series,

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -15,7 +15,7 @@
     "version": "0.2.4"
   },
   "dependencies": {
-    "grafanaVersion": "4.6.x 5.x"
+    "grafanaVersion": "5.3.3+"
   }
 }
 

--- a/src/series_overrides_ctrl.ts
+++ b/src/series_overrides_ctrl.ts
@@ -54,7 +54,7 @@ export class SeriesOverridesCtrl {
         element: $element.find('.dropdown')[0],
         position: 'top center',
         openOn: 'click',
-        template: '<series-color-picker series="series" onColorChange="colorSelected" />',
+        template: '<series-color-picker-popover series="series" onColorChange="colorSelected" />',
         model: {
           autoClose: true,
           colorSelected: $scope.colorSelected,


### PR DESCRIPTION
fixed #36 

`seriesColorPicker` Angular component was rewritten to React and renamed to `seriesColorPickerPopover` in this PR: grafana/grafana#13740

### Changes
`series-color-picker` -> `series-color-picker-popover`

Since this change only `5.3.3+` Grafana version supported

![image](https://user-images.githubusercontent.com/5675912/59515759-822b7400-8ec8-11e9-9c76-793f2d6e8fa3.png)
