### PR TITLE
Fix for issue #47

### DIFF
--- a/src/graph_renderer.ts
+++ b/src/graph_renderer.ts
@@ -350,6 +350,17 @@ export class GraphRenderer {
   }
 
   private _displaySideBySide(options) {
+    this.sortedSeries.forEach((series, index) => {
+      let datapoints = series.datapoints
+      let valuesDataPoints = []
+      datapoints.forEach((datapoint) => {
+        let dpval = datapoint[0]
+        if (dpval !== null){
+          valuesDataPoints.push(datapoint)
+        }
+      })
+      this.sortedSeries[index]["datapoints"] = valuesDataPoints
+    });
     let barsSeries = _.filter(this.sortedSeries, series => series.bars && series.bars.show !== false);
     let barWidth = options.series.bars.barWidth / barsSeries.length;
     for(let i = 0; i < barsSeries.length; ++i) {


### PR DESCRIPTION
Fix for issue #47 

Side by Side graph not able to show for weekly/yearly data for Prometheus data source.
Panel overlapping graph for weekly/yearly data because of data points were having null values for different timestamps.
The panel is not able to handle null datapoints and accepts only continuos values with null timestamps data points.
So as a fix to show side by side graph for weekly/yearly data filtering null values out from data points and hence it will work.

Filtering null value timestamps from datapoints will render daily/weekly/yearly side by side graphs seamlessly.